### PR TITLE
Fix Docker build due to wheel not being installed

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,10 @@ RUN set -ex && \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \
-  pip install hyde==0.8.9
+  pip install wheel
 
+RUN set -ex && \
+  pip install hyde==0.8.9
 EXPOSE 8080
 
 WORKDIR /tmp/website


### PR DESCRIPTION
Fixes the following problem I encountered while building the container (even with --no-cache) :

Building wheels for collected packages: hyde, MarkupSafe, PyYAML, commando, fswrap, typogrify
  Running setup.py bdist_wheel for hyde: started
  Running setup.py bdist_wheel for hyde: finished with status 'error'
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-jOtwJL/hyde/setup.py';f=getattr(tokenize, 'open', op
en)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmppvsUnPpip-wheel- --python-tag cp27:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help

  error: invalid command 'bdist_wheel'

  ----------------------------------------
  Failed building wheel for hyde
  Running setup.py clean for hyde
  Running setup.py bdist_wheel for MarkupSafe: started
  Running setup.py bdist_wheel for MarkupSafe: finished with status 'error'
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-jOtwJL/MarkupSafe/setup.py';f=getattr(tokenize, 'ope
n', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpVHIZv7pip-wheel- --python-tag c
p27:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help

  error: invalid command 'bdist_wheel'

  ----------------------------------------
  Failed building wheel for MarkupSafe
  Running setup.py clean for MarkupSafe
  Running setup.py bdist_wheel for PyYAML: started
  Running setup.py bdist_wheel for PyYAML: finished with status 'error'
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-jOtwJL/PyYAML/setup.py';f=getattr(tokenize, 'open',
open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpKTEntVpip-wheel- --python-tag cp27:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help

  error: invalid command 'bdist_wheel'

  ----------------------------------------
  Failed building wheel for PyYAML
  Running setup.py clean for PyYAML
  Running setup.py bdist_wheel for commando: started
  Running setup.py bdist_wheel for commando: finished with status 'error'

... etc.